### PR TITLE
removed dead link to SIMD

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,7 +77,6 @@
         <h2>Performance</h2>
         <ul>
           <li><a target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/JavaScript">JavaScript</a>, <a target="_blank" href="http://asmjs.org/">asm.js</a>, <a target="_blank" href="https://developer.mozilla.org/en-US/docs/WebAssembly">WebAssembly</a></li>
-          <li><a target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD">SIMD</a></li>
           <li><a target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API">Web workers</a></li>
           <li><a target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer">SharedArrayBuffer</a></li>
         </ul>


### PR DESCRIPTION
I removed the link to SIMD as the page no longer exists. and [SIMD.JS is not in active development](https://github.com/tc39/ecmascript_simd)